### PR TITLE
Rolling back to 5.0.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.2.2" %}
+{% set version = "5.0.5" %}
 
 package:
     name: xz
@@ -7,10 +7,10 @@ package:
 source:
     fn:  xz-{{ version }}.tar.bz2
     url: http://tukaani.org/xz/xz-{{ version }}.tar.gz
-    sha256: 73df4d5d34f0468bd57d09f2d8af363e95ed6cc3a4a86129d2f2c366259902a2
+    sha256: 5dcffe6a3726d23d1711a65288de2e215b4960da5092248ce63c99d50093b93a
 
 build:
-    number: 0
+    number: 2
     skip: True  # [win]
 
 test:
@@ -19,6 +19,7 @@ test:
         - unxz --help
         - lzma --help
         - conda inspect linkages -n _test xz  # [linux]
+        - otool -L $PREFIX/lib/liblzma.5.dylib  # [osx]
 
 about:
     home: http://tukaani.org/xz/


### PR DESCRIPTION
To do:
- [ ] Remove the `xz 5.2.2` binaries to avoid unpleasant updates.
- [ ] Check if we have version `8.0.0 or later` on OS X (whatever that means*)
- [ ] Rebuild `libxml2`, `libspatialite`, `libtiff`,  `openjpeg`, `gdal`, and `pynio` in that order.

*

``` shell
Reason: Incompatible library version: libtiff.5.dylib requires version 8.0.0 or later,
but liblzma.5.dylib provides version 6.0.0
```
