### PR TITLE
Downgrade xz 5.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
       conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://tukaani.org/xz/
 
 Package license: LGPL-2.1 and GPL-2.0
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: The xz command is a very powerful program for compressing files
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.2.2" %}
+{% set version = "5.0.5" %}
 
 package:
     name: xz
@@ -7,10 +7,10 @@ package:
 source:
     fn:  xz-{{ version }}.tar.bz2
     url: http://tukaani.org/xz/xz-{{ version }}.tar.gz
-    sha256: 73df4d5d34f0468bd57d09f2d8af363e95ed6cc3a4a86129d2f2c366259902a2
+    sha256: 5dcffe6a3726d23d1711a65288de2e215b4960da5092248ce63c99d50093b93a
 
 build:
-    number: 0
+    number: 1
     skip: True  # [win]
 
 test:


### PR DESCRIPTION
This is to avoid conflicting with Python 3.4 and 3.5 that are both compiled against this older version.
