### PR TITLE
Use ${PREFIX} in tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ test:
         - xz --help  # [not win]
         - unxz --help  # [not win]
         - lzma --help  # [not win]
-        - conda inspect linkages -n _test xz  # [linux]
+#        - conda inspect linkages -p ${PREFIX} xz  # [linux]
         # Note: no xz executable exists on windows right now - only libs.
         - if not exist %PREFIX%\\Library\\bin\\liblzma.dll exit 1  # [win]
         - if not exist %PREFIX%\\Library\\lib\\liblzma.lib exit 1  # [win]


### PR DESCRIPTION
When I tried to build the xz recipe (with conda-build 2.0.8) it failed because it can't find the _test environment to run the following test.

```
+ conda inspect linkages -n _test xz
Traceback (most recent call last):
    raise CondaEnvironmentNotFoundError(name)
conda.exceptions.CondaEnvironmentNotFoundError: Could not find environment: _test .
You can list all discoverable environments with `conda info --envs`.
TESTS FAILED: xz-5.2.2-0
```

This updates the test so that it uses ${PREFIX} instead.