### PR TITLE
Fix `xz-gpl-tools` license and requirement from `xz`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -154,11 +154,9 @@ outputs:
         - xzless --help
         - xzmore --help
     about:
-      license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+      license: GPL-2.0-or-later
       license_file:
         - COPYING
-        - COPYING.0BSD
-        - COPYING.LGPLv2.1
         - COPYING.GPLv2
   - name: xz
     build:
@@ -184,7 +182,6 @@ outputs:
         - {{ pin_subpackage('liblzma', exact=True) }}
         - {{ pin_subpackage('liblzma-devel', exact=True) }}
         - {{ pin_subpackage('xz-tools', exact=True) }}
-        - {{ pin_subpackage('xz-gpl-tools', exact=True) }}  # [unix]
     test:
       commands:
         - xz --help  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b1d45295d3f71f25a4c9101bd7c8d16cb56348bbef3bbc738da0351e17c73317
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # XZ's track record of backcompat is very good.  Keep default pins (next major version)
     #    https://abi-laboratory.pro/tracker/timeline/xz/


### PR DESCRIPTION
* Fix the license for the `xz-gpl-tools`
* No longer make `xz-gpl-tools` a requirement for `xz`, as doing otherwise prevents using `xz` in non-GPL environments.

Fix #45

