### PR TITLE
add run_constrained on xz from liblzma

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -16,5 +16,3 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 target_platform:
 - linux-64
-xz:
-- '5'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -16,5 +16,3 @@ docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
 target_platform:
 - linux-aarch64
-xz:
-- '5'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -16,5 +16,3 @@ docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le:alma9
 target_platform:
 - linux-ppc64le
-xz:
-- '5'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -18,5 +18,3 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
 - osx-64
-xz:
-- '5'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -18,5 +18,3 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:
 - osx-arm64
-xz:
-- '5'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -8,5 +8,3 @@ channel_targets:
 - conda-forge main
 target_platform:
 - win-64
-xz:
-- '5'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "5.6.3" %}
+{% set build = 2 %}
 
 package:
   name: xz-split
@@ -9,7 +10,7 @@ source:
   sha256: b1d45295d3f71f25a4c9101bd7c8d16cb56348bbef3bbc738da0351e17c73317
 
 build:
-  number: 1
+  number: {{ build }}
   run_exports:
     # XZ's track record of backcompat is very good.  Keep default pins (next major version)
     #    https://abi-laboratory.pro/tracker/timeline/xz/
@@ -39,6 +40,10 @@ outputs:
         - cmake-no-system  # [win]
         - ninja  # [win]
         - make  # [not win]
+      run_constrained:
+        # circular constraint on this build's xz to prevent accepting pre-split xz
+        # this is as close to 'exact' as we can get
+        xz =={{ version }} *_{{ build }}
     test:
       commands:
         - if not exist %LIBRARY_PREFIX%\bin\liblzma.dll exit 1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ outputs:
       run_constrained:
         # circular constraint on this build's xz to prevent accepting pre-split xz
         # this is as close to 'exact' as we can get
-        xz =={{ version }} *_{{ build }}
+        - xz =={{ version }} *_{{ build }}
     test:
       commands:
         - if not exist %LIBRARY_PREFIX%\bin\liblzma.dll exit 1  # [win]


### PR DESCRIPTION
suggested alternative in https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/936

still needs a repodata patch to apply this constraint to the published liblzma so far to fully address the conflict for older xz