### PR TITLE
Add a run_constrained on xz to ensure non-coinstallability with the unsplitted xz

### DIFF
--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 507825b599356c10dca1cd720c9d0d0c9d5400b9de300af00e4d1ea150795543
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # XZ's track record of backcompat is very good.  Keep default pins (next major version)
     #    https://abi-laboratory.pro/tracker/timeline/xz/
@@ -40,6 +40,9 @@ outputs:
         - cmake-no-system  # [win]
         - ninja  # [win]
         - make  # [not win]
+      run_constrained:
+        # Ensure this collides with the unsplitted version
+        - xz {{ version }}.*
     test:
       commands:
         - if not exist %LIBRARY_PREFIX%\bin\liblzma.dll exit 1  # [win]
@@ -99,6 +102,9 @@ outputs:
         - {{ pin_subpackage('liblzma-devel', exact=True) }}
       run:
         - {{ pin_subpackage('liblzma', exact=True) }}
+      run_constrained:
+        # Ensure this collides with the unsplitted version
+        - xz {{ version }}.*
     test:
       commands:
         - lzcat --help  # [unix]
@@ -138,6 +144,9 @@ outputs:
         - {{ pin_subpackage('xz-tools', exact=True) }}
       run:
         - {{ pin_subpackage('liblzma', exact=True) }}
+      run_constrained:
+        # Ensure this collides with the unsplitted version
+        - xz {{ version }}.*
     test:
       commands:
         - lzcmp --help
@@ -222,6 +231,9 @@ outputs:
         - {{ pin_subpackage('liblzma-devel', exact=True) }}
       run:
         - {{ pin_subpackage('liblzma-devel', exact=True) }}
+      run_constrained:
+        # Ensure this collides with the unsplitted version
+        - xz {{ version }}.*
     test:
       commands:
         - test -f ${PREFIX}/lib/liblzma.a          # [unix]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
